### PR TITLE
Remove a non-ascii character in cuda source code.

### DIFF
--- a/qmb/_hamiltonian_cuda.cu
+++ b/qmb/_hamiltonian_cuda.cu
@@ -271,7 +271,7 @@ auto apply_within_interface(
 }
 
 __device__ void _mutex_lock(int* mutex) {
-    // I don’t know why we need to wait for these periods of time, but the examples in the CUDA documentation are written this way.
+    // I don't know why we need to wait for these periods of time, but the examples in the CUDA documentation are written this way.
     // https://docs.nvidia.com/cuda/cuda-c-programming-guide/#nanosleep-example
     unsigned int ns = 8;
     while (atomicCAS(mutex, 0, 1) == 1) {


### PR DESCRIPTION
<!-- Thank you for contributing to qmb! -->

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

I do not know why but sometimes torch extension loader could complain it is non-ascii. I cannot reproduce this issue, but it exist instead sometimes, since it is very easy to fix, let's fix it.

![640fa51a23386ade27bfd861f210feb7](https://github.com/user-attachments/assets/c13e3ce9-f760-436a-b2f2-d1448ccf850b)

# Checklist:

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md).
