### PR TITLE
Fix torch import error in docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Use the specified CUDA base image with Rocky Linux 9
-FROM nvidia/cuda:12.6.3-cudnn-devel-rockylinux9
+FROM nvidia/cuda:12.8.1-cudnn-devel-rockylinux9
 
 # Install dependencies
 WORKDIR /app
 RUN dnf update --assumeyes && \
-    dnf install --assumeyes git python3.12-devel && \
+    dnf install --assumeyes git python3.12-devel libcusparselt-devel && \
     dnf clean all && \
     python3.12 -m ensurepip && \
     pip3.12 install --upgrade pip


### PR DESCRIPTION
This fix is temperary, which maybe fixed in future release of torch. See https://github.com/pytorch/pytorch/issues/150399

BTW, we also update the docker base image version from cuda 12.6.3 to 12.8.1.

<!-- Thank you for contributing to qmb! -->

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

For torch 2.6.x, torch cannot be imported due to binary library missing, and we apply the temporary fix workaround to let the image works.

# Checklist:

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md).
