### PR TITLE
Add the introduction about `$QMB_MODEL_PATH` in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Typically, `qmb` requires a specific descriptor for a particular physical or che
 We have collected a set of such models [here][models-url].
 Users can clone or download this dataset into a folder named `models` within their current working directory.
 This folder `models` is the default location which `qmb` will search for the necessary model files.
+Alternatively, users can specify a custom path by setting the `$QMB_MODEL_PATH` environment variable, thereby overriding the default behavior.
 
 After cloning or downloading the dataset, users can calculate the ground state of the $N_2$ system by running the command:
 ```


### PR DESCRIPTION
<!-- Thank you for contributing to qmb! -->

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

When the README was written first time, we did not support to use this environment variable to override this default behavior. But this setting is really useful sometimes, otherwise we must run the program in the same folder of the parent of models path. So we add this to README.

# Checklist:

- [X] have read the [CONTRIBUTING.md](CONTRIBUTING.md).
