### PR TITLE
Update the build-system version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=69.5.1", "setuptools_scm~=8.1.0"]
+requires = ["setuptools~=78.0.0", "setuptools_scm~=8.2.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
<!-- Thank you for contributing to qmb! -->

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

I find we can not run `pip install .` using the old version of setuptools and setuptools_scm, so update it.

# Checklist:

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md).
