### PR TITLE
Add option to set ref energy of ising like model by command line.

### DIFF
--- a/qmb/ising.py
+++ b/qmb/ising.py
@@ -58,6 +58,9 @@ class ModelConfig:
     # The coefficient of ZZ for antidiagonal bond
     za: typing.Annotated[float, tyro.conf.arg(aliases=["-za"])] = 0
 
+    # The ref energy of the model
+    ref_energy: typing.Annotated[float, tyro.conf.arg(aliases=["-r"])] = 0
+
 
 class Model(ModelProto[ModelConfig]):
     """
@@ -212,7 +215,8 @@ class Model(ModelProto[ModelConfig]):
         hamiltonian_dict: dict[tuple[tuple[int, int], ...], complex] = self._prepare_hamiltonian(args)
         logging.info("Hamiltonian initialization complete")
 
-        self.ref_energy: float = torch.nan
+        self.ref_energy: float = args.ref_energy
+        logging.info("The ref energy is set to %.10f", self.ref_energy)
 
         logging.info("Converting the Hamiltonian to internal Hamiltonian representation")
         self.hamiltonian: Hamiltonian = Hamiltonian(hamiltonian_dict, kind="bose2")


### PR DESCRIPTION
<!-- Thank you for contributing to qmb! -->

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR introduces an option to set the reference energy for Ising-like models. The addition is necessary for improved logging across multiple subprograms that utilize reference energy to record valuable output metrics, such as error measurements.

Additionally, the previous implementation addresses a potential issue where NaN values could lead to erroneous outputs. By setting 0 as the default reference energy value, we ensure program stability (preventing crashes) even though this default does not yield physically meaningful results.

# Checklist:

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md).
