### PR TITLE
Add support for setting pypi mirror during docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-ARG PYPI_MIRROR=https://pypi.org/simple
-
 # Use the specified CUDA base image with Rocky Linux 9
 FROM nvidia/cuda:12.8.1-cudnn-devel-rockylinux9
 
@@ -7,13 +5,14 @@ FROM nvidia/cuda:12.8.1-cudnn-devel-rockylinux9
 WORKDIR /app
 RUN dnf update --assumeyes && \
     dnf install --assumeyes git python3.12-devel libcusparselt-devel && \
-    dnf clean all && \
-    python3.12 -m ensurepip && \
-    pip3.12 install --index-url $PYPI_MIRROR --upgrade pip
+    dnf clean all
+ARG PYPI_MIRROR=https://pypi.org/simple
+RUN python3.12 -m ensurepip && \
+    pip3.12 install --index-url=${PYPI_MIRROR} --upgrade pip
 
 # Install the package
 COPY . /app
-RUN pip3.12 install --index-url $PYPI_MIRROR .
+RUN pip3.12 install --index-url=${PYPI_MIRROR} .
 ENV XDG_DATA_HOME=/tmp/data XDG_CONFIG_HOME=/tmp/config XDG_CACHE_HOME=/tmp/cache XDG_STATE_HOME=/tmp/state
 
 # Set the entrypoint


### PR DESCRIPTION
<!-- Thank you for contributing to qmb! -->

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Pypi mirror setting is essential for building docker image in some case, while mirror url is not suitable to be hard coded. This PR use docker ARG to specify it, users can build the docker image like `docker build --build-arg PYPI_MIRROR=https://mirrors.ustc.edu.cn/pypi/simple .`

# Checklist:

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md).
