### PR TITLE
解决windows上cpp和cu文件未被打包的问题

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ qmb = "qmb.__main__:main"
 [tool.setuptools.packages.find]
 include = ["qmb"]
 
+[tool.setuptools.package-data]
+qmb = ["*.cpp", "*.cu"]
+
 [tool.setuptools_scm]
 version_file = "qmb/_version.py"
 version_scheme = "no-guess-dev"


### PR DESCRIPTION
<!-- Thank you for contributing to qmb! -->

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

修改pyproject.toml, 在62-63行将.cpp和.cu类型设为包data
似乎setuptools默认只收集.py文件，需要额外指定。

# Checklist:

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md).
