### PR TITLE
Fix previous deprecated warning in license specification.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,11 @@ requires-python = ">=3.12"
 authors = [{ name = "Hao Zhang", email = "hzhangxyz@outlook.com" }]
 description = "Quantum Manybody Problem"
 readme = "README.md"
-license = {text = "GPLv3"}
+license = "GPL-3.0-or-later"
 keywords = ["quantum", "manybody", "quantum-chemistry", "quantum-simulation", "molecular-simulation", "algorithms", "simulation", "wave-function", "ground-state", "ansatz", "torch", "pytorch"]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Environment :: Console",
-  "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
   "Programming Language :: C++",
   "Programming Language :: Python :: 3",
   "Environment :: GPU :: NVIDIA CUDA",


### PR DESCRIPTION
<!-- Thank you for contributing to qmb! -->

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The new format of license for pyproject should be a valid SPDX license expression.

see: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license

# Checklist:

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md).
