### PR TITLE
Use itertools.pairwise when constructing MLP network.

### DIFF
--- a/qmb/crossmlp.py
+++ b/qmb/crossmlp.py
@@ -2,6 +2,7 @@
 This file implements a cross MLP network.
 """
 
+import itertools
 import typing
 import torch
 from .bitspack import unpack_int
@@ -48,7 +49,7 @@ class MLP(torch.nn.Module):
         self.depth: int = len(hidden_size)
 
         dimensions: list[int] = [dim_input] + list(hidden_size) + [dim_output]
-        linears: list[torch.nn.Module] = [select_linear_layer(i, j) for i, j in zip(dimensions[:-1], dimensions[1:])]
+        linears: list[torch.nn.Module] = [select_linear_layer(i, j) for i, j in itertools.pairwise(dimensions)]
         modules: list[torch.nn.Module] = [module for linear in linears for module in (linear, torch.nn.SiLU())][:-1]
         self.model: torch.nn.Module = torch.nn.Sequential(*modules)
 

--- a/qmb/mlp.py
+++ b/qmb/mlp.py
@@ -2,6 +2,7 @@
 This file implements the MLP network from https://arxiv.org/pdf/2109.12606 with the sampling method introduced in https://arxiv.org/pdf/2408.07625.
 """
 
+import itertools
 import torch
 from .bitspack import pack_int, unpack_int
 
@@ -47,7 +48,7 @@ class MLP(torch.nn.Module):
         self.depth: int = len(hidden_size)
 
         dimensions: list[int] = [dim_input] + list(hidden_size) + [dim_output]
-        linears: list[torch.nn.Module] = [select_linear_layer(i, j) for i, j in zip(dimensions[:-1], dimensions[1:])]
+        linears: list[torch.nn.Module] = [select_linear_layer(i, j) for i, j in itertools.pairwise(dimensions)]
         modules: list[torch.nn.Module] = [module for linear in linears for module in (linear, torch.nn.SiLU())][:-1]
         self.model: torch.nn.Module = torch.nn.Sequential(*modules)
 


### PR DESCRIPTION
<!-- Thank you for contributing to qmb! -->

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

As mentioned by https://github.com/USTC-KnowledgeComputingLab/qmb/pull/14#discussion_r2104172634 , we could use `itertools.pairwise` to improve the readability of codes during constructing MLP network.

# Checklist:

- [X] I have read the [CONTRIBUTING.md](/CONTRIBUTING.md).
- [x] Waiting for #14
