### PR TITLE
Remove useless attribute `depth` for mlp network.

### DIFF
--- a/qmb/crossmlp.py
+++ b/qmb/crossmlp.py
@@ -45,7 +45,6 @@ class MLP(torch.nn.Module):
         self.dim_input: int = dim_input
         self.dim_output: int = dim_output
         self.hidden_size: tuple[int, ...] = hidden_size
-        self.depth: int = len(hidden_size)
 
         dimensions: list[int] = [dim_input] + list(hidden_size) + [dim_output]
         linears: list[torch.nn.Module] = [select_linear_layer(i, j) for i, j in zip(dimensions[:-1], dimensions[1:])]

--- a/qmb/mlp.py
+++ b/qmb/mlp.py
@@ -44,7 +44,6 @@ class MLP(torch.nn.Module):
         self.dim_input: int = dim_input
         self.dim_output: int = dim_output
         self.hidden_size: tuple[int, ...] = hidden_size
-        self.depth: int = len(hidden_size)
 
         dimensions: list[int] = [dim_input] + list(hidden_size) + [dim_output]
         linears: list[torch.nn.Module] = [select_linear_layer(i, j) for i, j in zip(dimensions[:-1], dimensions[1:])]


### PR DESCRIPTION
<!-- Thank you for contributing to qmb! -->

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The attribute `depth` for MLP network is useless, this pr removes it.

# Checklist:

- [X] I have read the [CONTRIBUTING.md](/CONTRIBUTING.md).
- [x] Waiting for #14
