### PR TITLE
Set setuptools scm fallback version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ qmb = ["*.cpp", "*.cu"]
 [tool.setuptools_scm]
 version_file = "qmb/_version.py"
 version_scheme = "no-guess-dev"
+fallback_version = "0.0.0"
 
 [tool.yapf]
 based_on_style = "google"


### PR DESCRIPTION
<!-- Thank you for contributing to qmb! -->

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Sometimes such as downloading code directly without git repo, python packaging will fail as setup tools failed to determined the version, to avoid such failure, we need to add an fallback version for it.

# Checklist:

- [X] I have read the [CONTRIBUTING.md](/CONTRIBUTING.md).
