### PR TITLE
Fix wrong return type in `set_bit` in cuda kernel.

### DIFF
--- a/qmb/_hamiltonian_cuda.cu
+++ b/qmb/_hamiltonian_cuda.cu
@@ -42,7 +42,7 @@ __device__ bool get_bit(std::uint8_t* data, std::uint8_t index) {
     return ((*data) >> index) & 1;
 }
 
-__device__ bool set_bit(std::uint8_t* data, std::uint8_t index, bool value) {
+__device__ void set_bit(std::uint8_t* data, std::uint8_t index, bool value) {
     if (value) {
         *data |= (1 << index);
     } else {


### PR DESCRIPTION
<!-- Thank you for contributing to qmb! -->

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fix wrong return type in `set_bit` in cuda kernel.

# Checklist:

- [X] I have read the [CONTRIBUTING.md](/CONTRIBUTING.md).
