### PR TITLE
Check devices matching during load random seed for device.

### DIFF
--- a/qmb/imag.py
+++ b/qmb/imag.py
@@ -16,7 +16,6 @@ from .common import CommonConfig
 from .subcommand_dict import subcommand_dict
 from .model_dict import ModelProto
 from .optimizer import initialize_optimizer, scale_learning_rate
-from .random_engine import dump_random_engine_state
 
 
 @dataclasses.dataclass
@@ -513,7 +512,6 @@ class ImaginaryConfig:
             data["imag"]["global"] += 1
             data["network"] = network.state_dict()
             data["optimizer"] = optimizer.state_dict()
-            data["random"] = {"host": torch.get_rng_state(), "device": dump_random_engine_state(self.common.device)}
             self.common.save(data, data["imag"]["global"])
             logging.info("Checkpoint successfully saved")
 

--- a/qmb/rldiag.py
+++ b/qmb/rldiag.py
@@ -14,7 +14,6 @@ from .subcommand_dict import subcommand_dict
 from .model_dict import ModelProto
 from .optimizer import initialize_optimizer
 from .bitspack import pack_int
-from .random_engine import dump_random_engine_state
 
 
 def lanczos_energy(model: ModelProto, configs: torch.Tensor, step: int, threshold: float) -> tuple[float, torch.Tensor]:
@@ -215,7 +214,6 @@ class RldiagConfig:
             data["rldiag"]["local"] += 1
             data["network"] = network.state_dict()
             data["optimizer"] = optimizer.state_dict()
-            data["random"] = {"host": torch.get_rng_state(), "device": dump_random_engine_state(self.common.device)}
             self.common.save(data, data["rldiag"]["global"])
             logging.info("Checkpoint successfully saved")
 

--- a/qmb/vmc.py
+++ b/qmb/vmc.py
@@ -11,7 +11,6 @@ import tyro
 from .common import CommonConfig
 from .subcommand_dict import subcommand_dict
 from .optimizer import initialize_optimizer
-from .random_engine import dump_random_engine_state
 
 
 @dataclasses.dataclass
@@ -133,7 +132,6 @@ class VmcConfig:
             data["vmc"]["global"] += 1
             data["network"] = network.state_dict()
             data["optimizer"] = optimizer.state_dict()
-            data["random"] = {"host": torch.get_rng_state(), "device": dump_random_engine_state(self.common.device)}
             self.common.save(data, data["vmc"]["global"])
             logging.info("Checkpoint successfully saved")
 


### PR DESCRIPTION
<!-- Thank you for contributing to qmb! -->

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

When dumping random state for one device but loading it from another, the format of random state differs so program will raise error, we need to check whether the device type is unchanged before loading it.

# Checklist:

- [X] I have read the [CONTRIBUTING.md](/CONTRIBUTING.md).
