### PR TITLE
Avoid to invoke `logging.info` before calling `logging.basicConfig`.

### DIFF
--- a/qmb/hubbard.py
+++ b/qmb/hubbard.py
@@ -29,7 +29,7 @@ class ModelConfig:
     # The coefficient of U
     u: typing.Annotated[float, tyro.conf.arg(aliases=["-u"])] = 0
 
-    # The electron number
+    # The electron number, left empty for half-filling
     electron_number: typing.Annotated[int | None, tyro.conf.arg(aliases=["-e"])] = None
 
     # The ref energy of the model
@@ -38,7 +38,6 @@ class ModelConfig:
     def __post_init__(self) -> None:
         if self.electron_number is None:
             self.electron_number = self.m * self.n
-            logging.info("Electron number is not specified, set to half-filling (one electron per lattice site) %d", self.electron_number)
 
         if self.m <= 0 or self.n <= 0:
             raise ValueError("The dimensions of the Hubbard model must be positive integers.")


### PR DESCRIPTION


<!-- Thank you for contributing to qmb! -->

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

When we call logging.info before calling logging.basicConfig, logging.basicConfig may fail, so in the previous code, if our electron number is missing, we would see an empty logging. So this commit does not logging the information about missing electron number instead to save the logging basic config.

# Checklist:

- [X] I have read the [CONTRIBUTING.md](/CONTRIBUTING.md).
