### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,4 +1,6 @@
 name: Build wheels
+permissions:
+  contents: read
 
 on:
   - push
@@ -8,8 +10,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/USTC-KnowledgeComputingLab/qmp-kit/security/code-scanning/2](https://github.com/USTC-KnowledgeComputingLab/qmp-kit/security/code-scanning/2)

To fix this problem, an explicit `permissions` block should be added to the workflow, limiting the GITHUB_TOKEN's permissions to the minimum actually needed by the `build` job. Since this job only checks out the code, builds, and uploads artifacts (all of which can be done with `contents: read`), we should specify `permissions: contents: read` for the `build` job. This will override any broader default permissions from the repository or organization.

To do so, add the following block just above/within the `build` job (after `runs-on: ubuntu-latest` or before `steps:`):

```yaml
permissions:
  contents: read
```

No changes are needed outside of the `.github/workflows/wheels.yml` file within the `build` job. No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
