### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: Pre-commit Hooks
+permissions:
+  contents: read
 
 on:
   - push


### PR DESCRIPTION
Potential fix for [https://github.com/USTC-KnowledgeComputingLab/qmp-kit/security/code-scanning/1](https://github.com/USTC-KnowledgeComputingLab/qmp-kit/security/code-scanning/1)

To fix this problem, add an explicit `permissions` block restricting GITHUB_TOKEN to the least privilege necessary. Since this workflow only checks out code, installs dependencies, and runs pre-commit checks, it should only need read permission on repository contents. The optimal placement for the `permissions` block is at the root of the workflow (above `jobs: ...`), unless finer-grained permissions are needed for specific jobs. The recommended change is to add the following at the top level:

```yaml
permissions:
  contents: read
```

Simply add these lines after the workflow `name` and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
