### PR TITLE
feat(models): add list_relative to ModelProto and implementations

### DIFF
--- a/qmp/models/fcidump.py
+++ b/qmp/models/fcidump.py
@@ -184,6 +184,14 @@ class Model(ModelProto[ModelConfig]):
     ) -> torch.Tensor:
         return self.hamiltonian.find_relative(configs_i, psi_i, count_selected, configs_exclude)
 
+    def list_relative(
+        self,
+        configs_i: torch.Tensor,
+        psi_i: torch.Tensor,
+        configs_exclude: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.hamiltonian.list_relative(configs_i, psi_i, configs_exclude)
+
     def diagonal_term(self, configs: torch.Tensor) -> torch.Tensor:
         return self.hamiltonian.diagonal_term(configs)
 

--- a/qmp/models/hubbard.py
+++ b/qmp/models/hubbard.py
@@ -119,6 +119,14 @@ class Model(ModelProto[ModelConfig]):
     ) -> torch.Tensor:
         return self.hamiltonian.find_relative(configs_i, psi_i, count_selected, configs_exclude)
 
+    def list_relative(
+        self,
+        configs_i: torch.Tensor,
+        psi_i: torch.Tensor,
+        configs_exclude: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.hamiltonian.list_relative(configs_i, psi_i, configs_exclude)
+
     def diagonal_term(self, configs: torch.Tensor) -> torch.Tensor:
         return self.hamiltonian.diagonal_term(configs)
 

--- a/qmp/models/ising.py
+++ b/qmp/models/ising.py
@@ -195,6 +195,14 @@ class Model(ModelProto[ModelConfig]):
     ) -> torch.Tensor:
         return self.hamiltonian.find_relative(configs_i, psi_i, count_selected, configs_exclude)
 
+    def list_relative(
+        self,
+        configs_i: torch.Tensor,
+        psi_i: torch.Tensor,
+        configs_exclude: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.hamiltonian.list_relative(configs_i, psi_i, configs_exclude)
+
     def diagonal_term(self, configs: torch.Tensor) -> torch.Tensor:
         return self.hamiltonian.diagonal_term(configs)
 

--- a/qmp/models/openfermion.py
+++ b/qmp/models/openfermion.py
@@ -68,6 +68,14 @@ class Model(ModelProto[ModelConfig]):
     ) -> torch.Tensor:
         return self.hamiltonian.find_relative(configs_i, psi_i, count_selected, configs_exclude)
 
+    def list_relative(
+        self,
+        configs_i: torch.Tensor,
+        psi_i: torch.Tensor,
+        configs_exclude: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.hamiltonian.list_relative(configs_i, psi_i, configs_exclude)
+
     def diagonal_term(self, configs: torch.Tensor) -> torch.Tensor:
         return self.hamiltonian.diagonal_term(configs)
 

--- a/qmp/utility/model_dict.py
+++ b/qmp/utility/model_dict.py
@@ -161,6 +161,31 @@ class ModelProto(typing.Protocol[ModelConfig]):
             The relative configurations.
         """
 
+    def list_relative(
+        self,
+        configs_i: torch.Tensor,
+        psi_i: torch.Tensor,
+        configs_exclude: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        List all unique relative configurations and their accumulated amplitudes.
+
+        Parameters
+        ----------
+        configs_i : torch.Tensor
+            Input configurations (uint8).
+        psi_i : torch.Tensor
+            Input amplitudes (complex64).
+        configs_exclude : torch.Tensor, optional
+            Configurations to exclude from the result. Defaults to configs_i.
+
+        Returns
+        -------
+        tuple[torch.Tensor, torch.Tensor]
+            (configs_j, psi_j) where configs_j are unique new configurations
+            and psi_j are their summed amplitudes from all connected paths.
+        """
+
     def diagonal_term(self, configs: torch.Tensor) -> torch.Tensor:
         """
         Calculate the diagonal term for the given configurations.


### PR DESCRIPTION
- Added list_relative to ModelProto in model_dict.py.
- Implemented list_relative in Hubbard, FCIDUMP, OpenFermion, and Ising models by delegating to self.hamiltonian.